### PR TITLE
fix: correct typo 'Paye later' to 'Pay later' on checkout page

### DIFF
--- a/frontend/src/lang/checkout.ts
+++ b/frontend/src/lang/checkout.ts
@@ -53,7 +53,7 @@ const strings = new LocalizedStrings({
     SUCCESS: 'Your payment was successfully done. We sent you a confirmation email.',
     PAY_LATER_SUCCESS: 'Your booking was successfully done. We sent you a confirmation email.',
     PAYMENT_OPTIONS: 'Payment options',
-    PAY_LATER: 'Paye later',
+    PAY_LATER: 'Pay later',
     PAY_LATER_INFO: 'Free amendments and cancellation',
     PAY_ONLINE: 'Pay online',
     PAY_ONLINE_INFO: 'Amendments and cancellation under conditions',


### PR DESCRIPTION
###  What I Did
Fixed a typo in the checkout payment options. Previously displayed as **"Paye later"**, now corrected to **"Pay later"** in the English localization strings.


###  Verification
- Checked visually that the correction reflects on the UI.
- Confirmed it doesn't affect other payment flow logic.

Let me know if any changes are required!

@aelassas 
