### PR TITLE
removes version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   mongo:
     image: mongo:latest


### PR DESCRIPTION
- Docker was complaining about a deprecated feature. We removed the version property and the projects builds.
- Hatzlacha Rabbah